### PR TITLE
Fix crash when targetCoordinate not attached

### DIFF
--- a/showcaseview/src/main/java/com/joco/showcaseview/ShowcaseView.kt
+++ b/showcaseview/src/main/java/com/joco/showcaseview/ShowcaseView.kt
@@ -54,6 +54,9 @@ fun ShowcaseView(
     backgroundAlpha: BackgroundAlpha = BackgroundAlpha.Normal,
     dialog: @Composable (Rect) -> Unit
 ) {
+    // Prevent crash if coordinates are not attached
+    if (!targetCoordinates.isAttached) return
+
     val transition =  remember { MutableTransitionState(false) }
     val highlightDrawer = highlight.create(targetCoordinates = targetCoordinates)
 


### PR DESCRIPTION
This line ensures that if the screen changes (such as during navigation, recomposition, or configuration changes) and the targetCoordinates become detached from the layout tree while the animation is still running, the function will exit early. This prevents any attempt to access properties or methods of a detached LayoutCoordinates, which would otherwise cause a crash (IllegalStateException). Thus, it safely avoids layout-related crashes during UI transitions.